### PR TITLE
Feature/display dialog

### DIFF
--- a/WeatherAppSwiftUI.xcodeproj/project.pbxproj
+++ b/WeatherAppSwiftUI.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		A1ADD3462A556BBD00B0F7AA /* CustomModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADD3452A556BBD00B0F7AA /* CustomModifier.swift */; };
 		A1ADD3492A5570FB00B0F7AA /* ExImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADD3482A5570FB00B0F7AA /* ExImage.swift */; };
 		A1ADD3512A56978D00B0F7AA /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADD3502A56978D00B0F7AA /* SplashViewModel.swift */; };
+		A1B268242A661591003E06B9 /* ExView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B268232A661591003E06B9 /* ExView.swift */; };
 		A1D4A8C72A56ED0C004845ED /* SelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D4A8C62A56ED0C004845ED /* SelectViewModel.swift */; };
 		A1D4A8C92A57D297004845ED /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D4A8C82A57D297004845ED /* DetailViewModel.swift */; };
 		A1D4A8CB2A57D9DB004845ED /* WeatherData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D4A8CA2A57D9DB004845ED /* WeatherData.swift */; };
@@ -48,6 +49,7 @@
 		A1ADD3452A556BBD00B0F7AA /* CustomModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomModifier.swift; sourceTree = "<group>"; };
 		A1ADD3482A5570FB00B0F7AA /* ExImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExImage.swift; sourceTree = "<group>"; };
 		A1ADD3502A56978D00B0F7AA /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
+		A1B268232A661591003E06B9 /* ExView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExView.swift; sourceTree = "<group>"; };
 		A1D4A8C62A56ED0C004845ED /* SelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectViewModel.swift; sourceTree = "<group>"; };
 		A1D4A8C82A57D297004845ED /* DetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewModel.swift; sourceTree = "<group>"; };
 		A1D4A8CA2A57D9DB004845ED /* WeatherData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherData.swift; sourceTree = "<group>"; };
@@ -142,6 +144,7 @@
 		A1ADD3472A5570DF00B0F7AA /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				A1B268232A661591003E06B9 /* ExView.swift */,
 				A1ADD3482A5570FB00B0F7AA /* ExImage.swift */,
 				A1DDB2F02A56E561000415F4 /* ExButton.swift */,
 				A1D4A8CE2A57FE84004845ED /* ExDouble.swift */,
@@ -282,6 +285,7 @@
 				A1ADD3412A55493300B0F7AA /* PrefectureData.swift in Sources */,
 				A1ADD3462A556BBD00B0F7AA /* CustomModifier.swift in Sources */,
 				A1ADD3512A56978D00B0F7AA /* SplashViewModel.swift in Sources */,
+				A1B268242A661591003E06B9 /* ExView.swift in Sources */,
 				A1A341832A5403C200B545C6 /* SplashView.swift in Sources */,
 				A1A341902A54FE7D00B545C6 /* MainViewModel.swift in Sources */,
 				A1DDB2F32A56E5DC000415F4 /* MainView.swift in Sources */,

--- a/WeatherAppSwiftUI/Extension/ExView.swift
+++ b/WeatherAppSwiftUI/Extension/ExView.swift
@@ -1,0 +1,28 @@
+//
+//  ExView.swift
+//  WeatherAppSwiftUI
+//
+
+//
+
+import SwiftUI
+
+extension View {
+    ///位置情報取得不可時のアラートをカスタムモディファイアメソッドにしたもの
+    func notGetLocationAlertModifier(isPresented: Binding<Bool>) -> some View {
+        self
+            // テキストを省略させないモディファイア
+            .alert("位置情報が取得できません", isPresented: isPresented) {
+                Button("閉じる") {
+                    print("閉じる押した")
+                }
+                Button("設定") {
+                    print("設定画面へ遷移")
+                    UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                }
+            } message: {
+                Text("端末設定を見直してください")
+            }
+
+    }
+}

--- a/WeatherAppSwiftUI/View/MainView.swift
+++ b/WeatherAppSwiftUI/View/MainView.swift
@@ -84,6 +84,7 @@ struct MainView: View {
                 toDetailViewButton
             }
         }
+
         .navigationTitle(Text("Home"))
         .navigationBarTitleDisplayMode(.inline)
         // 戻るボタンを非表示
@@ -93,6 +94,8 @@ struct MainView: View {
                 notificationButton
             }
         }
+        // 位置情報取得不可時のアラート
+        .notGetLocationAlertModifier(isPresented: $mainViewModel.isDisplayNotGetLocDialog)
     }
 }
 

--- a/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
+++ b/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
@@ -12,6 +12,7 @@ class MainViewModel: ObservableObject {
     @Published var isSelectPrefectureButtonTapped = false
     @Published var isGetLocationButtonTapped = false
     @Published var isDisplayDetailView = false
+    @Published var isDisplayNotGetLocDialog = false
     /// 通知予約の有無を示す変数
     @Published var isNotification = false
     
@@ -40,6 +41,7 @@ class MainViewModel: ObservableObject {
 
         } else {
             print("アプリの位置情報取得が許可されていません")
+            isDisplayNotGetLocDialog = true
         }
     }
 }


### PR DESCRIPTION
## チケットへのリンク

- #9 

## やったこと

- 位置情報取得不可時のダイアログ実装

## やらないこと（あれば。無いなら「無し」でOK。やらない場合は、いつやるのかを明記する。）

- なし

## 動作確認

- 実機：iPhone13Pro

## その他：レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

- アラートをそのままViewに書くと冗長的になるのがSwiftUIの問題点であると思っていたが、カスタムモディファイアメソッドとすることで、改善することができ、コードを見やすく、まとめれたと思う。
