### PR TITLE
Feature/error handling

### DIFF
--- a/WeatherAppSwiftUI.xcodeproj/project.pbxproj
+++ b/WeatherAppSwiftUI.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		A1ADD3492A5570FB00B0F7AA /* ExImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADD3482A5570FB00B0F7AA /* ExImage.swift */; };
 		A1ADD3512A56978D00B0F7AA /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADD3502A56978D00B0F7AA /* SplashViewModel.swift */; };
 		A1B268242A661591003E06B9 /* ExView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B268232A661591003E06B9 /* ExView.swift */; };
+		A1B268262A664E11003E06B9 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B268252A664E11003E06B9 /* APIError.swift */; };
 		A1D4A8C72A56ED0C004845ED /* SelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D4A8C62A56ED0C004845ED /* SelectViewModel.swift */; };
 		A1D4A8C92A57D297004845ED /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D4A8C82A57D297004845ED /* DetailViewModel.swift */; };
 		A1D4A8CB2A57D9DB004845ED /* WeatherData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D4A8CA2A57D9DB004845ED /* WeatherData.swift */; };
@@ -50,6 +51,7 @@
 		A1ADD3482A5570FB00B0F7AA /* ExImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExImage.swift; sourceTree = "<group>"; };
 		A1ADD3502A56978D00B0F7AA /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
 		A1B268232A661591003E06B9 /* ExView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExView.swift; sourceTree = "<group>"; };
+		A1B268252A664E11003E06B9 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
 		A1D4A8C62A56ED0C004845ED /* SelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectViewModel.swift; sourceTree = "<group>"; };
 		A1D4A8C82A57D297004845ED /* DetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewModel.swift; sourceTree = "<group>"; };
 		A1D4A8CA2A57D9DB004845ED /* WeatherData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherData.swift; sourceTree = "<group>"; };
@@ -170,6 +172,7 @@
 			isa = PBXGroup;
 			children = (
 				A1D4A8DE2A5BE5C9004845ED /* API.swift */,
+				A1B268252A664E11003E06B9 /* APIError.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -277,6 +280,7 @@
 				A1D4A8D92A5ACCC1004845ED /* ExCLAuthorizationStatus.swift in Sources */,
 				A1D4A8CF2A57FE84004845ED /* ExDouble.swift in Sources */,
 				A1D4A8C72A56ED0C004845ED /* SelectViewModel.swift in Sources */,
+				A1B268262A664E11003E06B9 /* APIError.swift in Sources */,
 				A1DDB2F12A56E561000415F4 /* ExButton.swift in Sources */,
 				A1D4A8CB2A57D9DB004845ED /* WeatherData.swift in Sources */,
 				A1ADD3492A5570FB00B0F7AA /* ExImage.swift in Sources */,

--- a/WeatherAppSwiftUI/API/API.swift
+++ b/WeatherAppSwiftUI/API/API.swift
@@ -81,21 +81,6 @@ class API {
                 print("レスポンス取得失敗")
                 completion(.failure(.connectionError(error)))
             }
-//            guard let data = response.data else {
-//                print("dataが不適切？")
-//                return
-//            }
-//            let decoder = JSONDecoder()
-//            do {
-//                let response = try decoder.decode(WeatherData.self, from: data)
-////                print(response)
-//                completion(Result.success(response))
-//                print("成功")
-//            } catch {
-//                print("失敗")
-//                print(error.localizedDescription)
-//                completion(Result.failure(response as! Error))
-//            }
         }
         print("リクエストした")
     }

--- a/WeatherAppSwiftUI/API/API.swift
+++ b/WeatherAppSwiftUI/API/API.swift
@@ -45,14 +45,14 @@ class API {
     }
     // AFError型にたくさん種類があるが、独自に定義したエラーを使用
     /// 選択した都道府県をパラメータに追加してAPIリクエストする
-    func sendAPISelectedLocationRequest(selectLocation: String, completion: @escaping (Result<WeatherData, APIError>) -> Void) {
+    func sendAPISelectedLocationRequest(selectLocation: String, completion: @escaping (Result<WeatherData, AFError>) -> Void) {
         var baseParameters = buildBaseParameters()
         // 固有のパラメータを追加する。辞書型のため、appendではない
         baseParameters.updateValue(selectLocation, forKey: "q")
         sendAPIRequest(parameters: baseParameters, completion: completion)
     }
     /// 位置情報をパラメータに追加してAPIリクエストする
-    func sendAPIGotLocationRequest(latitude: Double, longitude: Double, completion: @escaping (Result<WeatherData, APIError>) -> Void) {
+    func sendAPIGotLocationRequest(latitude: Double, longitude: Double, completion: @escaping (Result<WeatherData, AFError>) -> Void) {
         var baseParameters = buildBaseParameters()
         // 固有のパラメータを追加する。辞書型のため、appendではない
         baseParameters.updateValue(latitude, forKey: "lat")
@@ -60,8 +60,7 @@ class API {
         sendAPIRequest(parameters: baseParameters, completion: completion)
     }
     /// APIリクエストの共通部分
-    func sendAPIRequest(parameters: Parameters, completion: @escaping (Result<WeatherData, APIError>) -> Void) {
-
+    func sendAPIRequest(parameters: Parameters, completion: @escaping (Result<WeatherData, AFError>) -> Void) {
         AF.request(urlString, method: method, parameters: parameters).response { response in
             switch response.result {
                 // レスポンスの取得成功
@@ -76,13 +75,14 @@ class API {
                 } catch {
                     // デコードエラー
                     print("デコード失敗")
-                    completion(.failure(.responseParseError(error)))
+                    print(error)
+                    completion(.failure(.parameterEncoderFailed(reason: .encoderFailed(error: error))))
                 }
                 // レスポンス取得失敗
             case .failure(let error):
                 // ネットワーク接続エラー
                 print("レスポンス取得失敗")
-                completion(.failure(.connectionError(error)))
+                completion(.failure(error))
             }
         }
         print("リクエストした")

--- a/WeatherAppSwiftUI/API/APIError.swift
+++ b/WeatherAppSwiftUI/API/APIError.swift
@@ -1,41 +1,42 @@
+////
+////  APIError.swift
+////  WeatherAppSwiftUI
+////
 //
-//  APIError.swift
-//  WeatherAppSwiftUI
+////
 //
-
+//import Foundation
+//import Alamofire
 //
-
-import Foundation
-
-enum APIError: Error {
-    // 通信失敗
-    case connectionError(Error)
-    // デコードエラー
-    case responseParseError(Error)
-    // APIエラー
-    case apiError(Error)
-    
-    /// ダイアログのタイトル
-    var title: String {
-        switch self {
-        case .connectionError:
-            return "通信エラー"
-        case .responseParseError:
-            return "デコードエラー"
-        case .apiError:
-            return "APIエラー"
-        }
-    }
-    /// ダイアログのメッセージ
-    var message: String {
-        switch self {
-        case .connectionError:
-            return "通信環境を確認してください。"
-        case .responseParseError:
-            return "デコードエラーです。開発者にお問い合わせください。"
-        case .apiError:
-            return "APIエラーです。開発者にお問い合わせください。"
-        }
-    }
-}
-
+//enum APIError: Error {
+//    // 通信失敗
+//    case connectionError(Error)
+//    // デコードエラー
+//    case responseParseError(Error)
+//    // APIエラー
+//    case apiError(Error)
+//    
+//    /// ダイアログのタイトル
+//    var title: String {
+//        switch self {
+//        case .connectionError:
+//            return "通信エラー"
+//        case .responseParseError:
+//            return "デコードエラー"
+//        case .apiError:
+//            return "APIエラー"
+//        }
+//    }
+//    /// ダイアログのメッセージ
+//    var message: String {
+//        switch self {
+//        case .connectionError:
+//            return "通信環境を確認してください。"
+//        case .responseParseError:
+//            return "デコードエラーです。開発者にお問い合わせください。"
+//        case .apiError:
+//            return "APIエラーです。開発者にお問い合わせください。"
+//        }
+//    }
+//}
+//

--- a/WeatherAppSwiftUI/API/APIError.swift
+++ b/WeatherAppSwiftUI/API/APIError.swift
@@ -1,0 +1,41 @@
+//
+//  APIError.swift
+//  WeatherAppSwiftUI
+//
+
+//
+
+import Foundation
+
+enum APIError: Error {
+    // 通信失敗
+    case connectionError(Error)
+    // デコードエラー
+    case responseParseError(Error)
+    // APIエラー
+    case apiError(Error)
+    
+    /// ダイアログのタイトル
+    var title: String {
+        switch self {
+        case .connectionError:
+            return "通信エラー"
+        case .responseParseError:
+            return "デコードエラー"
+        case .apiError:
+            return "APIエラー"
+        }
+    }
+    /// ダイアログのメッセージ
+    var message: String {
+        switch self {
+        case .connectionError:
+            return "通信環境を確認してください。"
+        case .responseParseError:
+            return "デコードエラーです。開発者にお問い合わせください。"
+        case .apiError:
+            return "APIエラーです。開発者にお問い合わせください。"
+        }
+    }
+}
+

--- a/WeatherAppSwiftUI/Extension/ExView.swift
+++ b/WeatherAppSwiftUI/Extension/ExView.swift
@@ -23,6 +23,17 @@ extension View {
             } message: {
                 Text("端末設定を見直してください")
             }
+    }
+    // APIエラー時のダイアログ
+    func errorAlertModifier(title: String, message: String, isPresented: Binding<Bool>) -> some View {
+        self
+            .alert(title, isPresented: isPresented) {
+                Button("閉じる") {
+                    
+                }
+            } message: {
+                Text(message)
+            }
 
     }
 }

--- a/WeatherAppSwiftUI/View/DetailView.swift
+++ b/WeatherAppSwiftUI/View/DetailView.swift
@@ -218,6 +218,10 @@ struct DetailView: View {
                 detailMainView
             }
         }
+        // APIエラー時に表示するダイアログ
+        .errorAlertModifier(title: detailViewModel.errorTitle ?? "仮アラートタイトル",
+                            message: detailViewModel.errorMessage ?? "仮アラートメッセージ",
+                            isPresented: $detailViewModel.isDisplayErrorDialog)
     }
 }
 

--- a/WeatherAppSwiftUI/ViewModel/DetailViewModel.swift
+++ b/WeatherAppSwiftUI/ViewModel/DetailViewModel.swift
@@ -90,8 +90,8 @@ class DetailViewModel: ObservableObject {
             case .failure(let error):
                 print("データ取得失敗")
                 print(error)
-                self.errorTitle = error.title
-                self.errorMessage = error.message
+                self.errorTitle = "エラー発生"
+                self.errorMessage = error.localizedDescription
                 self.isDisplayErrorDialog = true
             }
         }
@@ -107,8 +107,8 @@ class DetailViewModel: ObservableObject {
             case .failure(let error):
                 print("データ取得失敗")
                 print(error)
-                self.errorTitle = error.title
-                self.errorMessage = error.message
+                self.errorTitle = "エラー発生"
+                self.errorMessage = error.localizedDescription
                 self.isDisplayErrorDialog = true
             }
         }

--- a/WeatherAppSwiftUI/ViewModel/DetailViewModel.swift
+++ b/WeatherAppSwiftUI/ViewModel/DetailViewModel.swift
@@ -11,6 +11,10 @@ import CoreLocation
 class DetailViewModel: ObservableObject {
     // データモデルはオプショナル型で宣言し、最後に値を格納することで、仮データに惑わされないメリット
     @Published var savedWeatherData: SavedWeatherData?
+    @Published var isDisplayErrorDialog = false
+
+    @Published var errorTitle: String?
+    @Published var errorMessage: String?
     
     // デリゲートパターン⑤処理を任される側で、デリゲートを適用させる
     init() {
@@ -82,7 +86,10 @@ class DetailViewModel: ObservableObject {
                 self.saveAPIResponse(response: weather)
             case .failure(let error):
                 print("データ取得失敗")
-//                print(error)
+                print(error)
+                self.errorTitle = error.title
+                self.errorMessage = error.message
+                self.isDisplayErrorDialog = true
             }
         }
     }


### PR DESCRIPTION
## チケットへのリンク

- #11 

## やったこと

- 簡易的なAPIエラーハンドリングと、エラー時のアラート表示機能実装

## やらないこと（あれば。無いなら「無し」でOK。やらない場合は、いつやるのかを明記する。）

- アラートのボタンタップで詳細画面を閉じる処理の実装（現状難しそう）

## 動作確認

- 実機：iPhone13Pro

## その他：レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

- アラートの閉じるボタンに、dismissを引数として渡そうとしたが、アラートが表示された瞬間に実行される不具合があり、実装困難と思われる。
