### PR TITLE
Feature/notification

### DIFF
--- a/WeatherAppSwiftUI/Extension/ExView.swift
+++ b/WeatherAppSwiftUI/Extension/ExView.swift
@@ -38,26 +38,26 @@ extension View {
     }
     
     // 通知予約するダイアログ
-    func reserveNotificationAlertModifier(isPresented: Binding<Bool>, okClosure: @escaping () -> Void) -> some View {
+    func reserveNotificationAlertModifier(isPresented: Binding<Bool>, notificationTime: Binding<Date>, okClosure: @escaping () -> Void) -> some View {
         self
             .alert("通知予約しますか？", isPresented: isPresented) {
+                DatePicker("時刻を選択", selection: notificationTime,displayedComponents: .hourAndMinute)
                 Button("キャンセル") {
-//                    cancelAction
+
                 }
                 Button("予約する") {
                     okClosure()
                 }
             } message: {
-                Text("通知予約したい時間を選択してください")
+                Text("通知予約したい時間を設定してください")
             }
-
     }
     // 通知解除するか尋ねるダイアログ
     func releaseNotificationAlertModifier(isPresented: Binding<Bool>, okClosure: @escaping () -> Void) -> some View {
         self
             .alert("通知予約を解除しますか?", isPresented: isPresented) {
                 Button("キャンセル") {
-//                    cancelAction
+
                 }
                 Button("解除する") {
                     okClosure()
@@ -65,19 +65,17 @@ extension View {
             } message: {
                 Text("既に通知が予約されています。通知予約を解除してもよろしいでしょうか？")
             }
-
     }
     // 通知予約完了ダイアログ
-    func doneReserveNotificationAlertModifier(isPresented: Binding<Bool>) -> some View {
+    func doneReserveNotificationAlertModifier(isPresented: Binding<Bool>, notificationTimeString: String) -> some View {
         self
             .alert("通知予約完了", isPresented: isPresented) {
                 Button("OK") {
                     
                 }
             } message: {
-                Text("毎日指定した時間に通知が行われます")
+                Text("毎日\(notificationTimeString)に通知が行われます")
             }
-
     }
     // 通知予約解除完了ダイアログ
     func doneReleaseNotificationAlertModifier(isPresented: Binding<Bool>) -> some View {

--- a/WeatherAppSwiftUI/Extension/ExView.swift
+++ b/WeatherAppSwiftUI/Extension/ExView.swift
@@ -87,6 +87,22 @@ extension View {
             } message: {
                 Text("毎日の通知予約を解除しました。")
             }
-
+    }
+    
+    /// 通知許諾不可時のアラートをカスタムモディファイアメソッドにしたもの
+    func notPermissionNotificationAlertModifier(isPresented: Binding<Bool>) -> some View {
+        self
+            // テキストを省略させないモディファイア
+            .alert("通知が許可されていません", isPresented: isPresented) {
+                Button("閉じる") {
+                    print("閉じる押した")
+                }
+                Button("設定") {
+                    print("設定画面へ遷移")
+                    UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                }
+            } message: {
+                Text("端末設定を見直してください")
+            }
     }
 }

--- a/WeatherAppSwiftUI/Extension/ExView.swift
+++ b/WeatherAppSwiftUI/Extension/ExView.swift
@@ -36,4 +36,59 @@ extension View {
             }
 
     }
+    
+    // 通知予約するダイアログ
+    func reserveNotificationAlertModifier(isPresented: Binding<Bool>, okClosure: @escaping () -> Void) -> some View {
+        self
+            .alert("通知予約しますか？", isPresented: isPresented) {
+                Button("キャンセル") {
+//                    cancelAction
+                }
+                Button("予約する") {
+                    okClosure()
+                }
+            } message: {
+                Text("通知予約したい時間を選択してください")
+            }
+
+    }
+    // 通知解除するか尋ねるダイアログ
+    func releaseNotificationAlertModifier(isPresented: Binding<Bool>, okClosure: @escaping () -> Void) -> some View {
+        self
+            .alert("通知予約を解除しますか?", isPresented: isPresented) {
+                Button("キャンセル") {
+//                    cancelAction
+                }
+                Button("解除する") {
+                    okClosure()
+                }
+            } message: {
+                Text("既に通知が予約されています。通知予約を解除してもよろしいでしょうか？")
+            }
+
+    }
+    // 通知予約完了ダイアログ
+    func doneReserveNotificationAlertModifier(isPresented: Binding<Bool>) -> some View {
+        self
+            .alert("通知予約完了", isPresented: isPresented) {
+                Button("OK") {
+                    
+                }
+            } message: {
+                Text("毎日指定した時間に通知が行われます")
+            }
+
+    }
+    // 通知予約解除完了ダイアログ
+    func doneReleaseNotificationAlertModifier(isPresented: Binding<Bool>) -> some View {
+        self
+            .alert("通知予約解除完了", isPresented: isPresented) {
+                Button("OK") {
+                    
+                }
+            } message: {
+                Text("毎日の通知予約を解除しました。")
+            }
+
+    }
 }

--- a/WeatherAppSwiftUI/View/DetailView.swift
+++ b/WeatherAppSwiftUI/View/DetailView.swift
@@ -92,6 +92,8 @@ struct DetailView: View {
             Text("%")
                 .foregroundColor(.black)
         })
+        // パラメータガイドの上限値を明示する。これを指定しないと、降水確率０％の時、0%が上に来る不具合あり
+        .chartYScale(domain: 0...100)
         .frame(height: chartHeight)
         .padding()
     }

--- a/WeatherAppSwiftUI/View/MainView.swift
+++ b/WeatherAppSwiftUI/View/MainView.swift
@@ -99,32 +99,38 @@ struct MainView: View {
     var settingTimeView: some View {
         ZStack {
             Color(uiColor: .darkGray)
-            VStack {
+            VStack(spacing: 0) {
                 Text("通知を設定したい時間を選択")
                     .fontWeight(.bold)
                     .foregroundColor(.white)
+                    .padding()
+                Spacer()
                 DatePicker("時間を選択", selection: $mainViewModel.notificationTime, displayedComponents: .hourAndMinute)
                     .tint(.white)
                     .labelsHidden()
-                HStack {
+                // Buttonを下部に揃える
+                Spacer()
+                // 上線
+                Rectangle().frame(width: settingTimeViewWidth, height: 1)
+                HStack(spacing: 0) {
                     Button("キャンセル") {
                         mainViewModel.tappedReserveCancelButton()
                     }
-                    .padding()
-                    .frame(width: settingTimeViewWidth / 2.2)
+                    .padding(.vertical)
+                    .frame(width: settingTimeViewWidth / 2, height: settingTimeViewHeight / 4)
                     .background(Color(uiColor: .lightGray))
-                    .cornerRadius(30)
+                    Rectangle().frame(width: 1, height: settingTimeViewHeight / 4)
                     Button("設定") {
                         mainViewModel.tappedReserveOkButton()
                     }
-                    .padding()
-                    .frame(width: settingTimeViewWidth / 2.2)
+                    .padding(.vertical)
+                    .frame(width: settingTimeViewWidth / 2, height: settingTimeViewHeight / 4)
                     .background(Color(uiColor: .lightGray))
-                    .cornerRadius(30)
                 }
             }
         }
         .frame(width: settingTimeViewWidth, height: settingTimeViewHeight)
+        // 背景だけ角丸にすることで、実際のアラートっぽくできる！！！！！
         .cornerRadius(30)
     }
 

--- a/WeatherAppSwiftUI/View/MainView.swift
+++ b/WeatherAppSwiftUI/View/MainView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 struct MainView: View {
     @StateObject private var mainViewModel = MainViewModel()
     private var buttonWidth = UIScreen.main.bounds.width / 1.5
+    private var settingTimeViewWidth = UIScreen.main.bounds.width * 0.8
+    private var settingTimeViewHeight = UIScreen.main.bounds.height * 0.25
 
     /// ナビゲーションバーの設定を行うメソッド
     func setupNavigationBar() {
@@ -79,11 +81,11 @@ struct MainView: View {
         .releaseNotificationAlertModifier(isPresented: $mainViewModel.isPresentedReleaseNotificationAlert, okClosure: {
             mainViewModel.tappedReleaseOkButton()
         })
-        .reserveNotificationAlertModifier(isPresented: $mainViewModel.isPresentedReserveNotificationAlert, okClosure: {
-            mainViewModel.tappedReserveOkButton()
+        .reserveNotificationAlertModifier(isPresented: $mainViewModel.isPresentedReserveNotificationAlert, notificationTime: $mainViewModel.notificationTime, okClosure: {
+            mainViewModel.isSettingTime = true
         })
         .doneReleaseNotificationAlertModifier(isPresented: $mainViewModel.isPresentedDoneReleaseNotificationAlert)
-        .doneReserveNotificationAlertModifier(isPresented: $mainViewModel.isPresentedDoneReserveNotificationAlert)
+        .doneReserveNotificationAlertModifier(isPresented: $mainViewModel.isPresentedDoneReserveNotificationAlert, notificationTimeString: mainViewModel.notificationTimeString())
     }
 
     //背景色
@@ -92,6 +94,38 @@ struct MainView: View {
         LinearGradient(gradient: Gradient(colors: [.cyan, .white]), startPoint: .top, endPoint: .bottom)
             .ignoresSafeArea()
     }
+    /// 通知時間の設定画面（アラートに実装不可能なため）
+    var settingTimeView: some View {
+        ZStack {
+            Color(uiColor: .darkGray)
+            VStack {
+                Text("通知を設定したい時間を選択")
+                    .fontWeight(.bold)
+                    .foregroundColor(.white)
+                DatePicker("時間を選択", selection: $mainViewModel.notificationTime, displayedComponents: .hourAndMinute)
+                    .tint(.white)
+                    .labelsHidden()
+                HStack {
+                    Button("キャンセル") {
+                        mainViewModel.tappedReserveCancelButton()
+                    }
+                    .padding()
+                    .frame(width: settingTimeViewWidth / 2.2)
+                    .background(Color(uiColor: .lightGray))
+                    .cornerRadius(30)
+                    Button("設定") {
+                        mainViewModel.tappedReserveOkButton()
+                    }
+                    .padding()
+                    .frame(width: settingTimeViewWidth / 2.2)
+                    .background(Color(uiColor: .lightGray))
+                    .cornerRadius(30)
+                }
+            }
+        }
+        .frame(width: settingTimeViewWidth, height: settingTimeViewHeight)
+        .cornerRadius(30)
+    }
 
     var body: some View {
         ZStack {
@@ -99,6 +133,9 @@ struct MainView: View {
             VStack(spacing: 50) {
                 toSelectPrefectureViewButton
                 toDetailViewButton
+            }
+            if mainViewModel.isSettingTime {
+                settingTimeView
             }
         }
 

--- a/WeatherAppSwiftUI/View/MainView.swift
+++ b/WeatherAppSwiftUI/View/MainView.swift
@@ -78,6 +78,7 @@ struct MainView: View {
             Image(systemName: mainViewModel.notificationImageName())
                 .tint(.yellow)
         }
+        .notPermissionNotificationAlertModifier(isPresented: $mainViewModel.isNotNotificationAlert)
         .releaseNotificationAlertModifier(isPresented: $mainViewModel.isPresentedReleaseNotificationAlert, okClosure: {
             mainViewModel.tappedReleaseOkButton()
         })

--- a/WeatherAppSwiftUI/View/MainView.swift
+++ b/WeatherAppSwiftUI/View/MainView.swift
@@ -147,6 +147,8 @@ struct MainView: View {
         .toolbar() {
             ToolbarItem(placement: .navigationBarTrailing) {
                 notificationButton
+                // 時間設定中も押せてしまうので、阻止するために
+                    .disabled(mainViewModel.isSettingTime)
             }
         }
         // 位置情報取得不可時のアラート

--- a/WeatherAppSwiftUI/View/MainView.swift
+++ b/WeatherAppSwiftUI/View/MainView.swift
@@ -23,6 +23,16 @@ struct MainView: View {
     }
     init() {
         setupNavigationBar()
+        
+        let center = UNUserNotificationCenter.current()
+        // 通知の設定
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if granted {
+                print("通知許可された")
+            } else {
+                print("通知拒否された")
+            }
+        }
     }
 
     // 選択画面に遷移するボタン
@@ -61,12 +71,19 @@ struct MainView: View {
     //ナビゲーションバーに表示する通知ボタン
     var notificationButton: some View {
         Button {
-            //ダイアログ出す処理を記述
-            
+            mainViewModel.tappedNotificationButton()
         } label: {
             Image(systemName: mainViewModel.notificationImageName())
                 .tint(.yellow)
         }
+        .releaseNotificationAlertModifier(isPresented: $mainViewModel.isPresentedReleaseNotificationAlert, okClosure: {
+            mainViewModel.tappedReleaseOkButton()
+        })
+        .reserveNotificationAlertModifier(isPresented: $mainViewModel.isPresentedReserveNotificationAlert, okClosure: {
+            mainViewModel.tappedReserveOkButton()
+        })
+        .doneReleaseNotificationAlertModifier(isPresented: $mainViewModel.isPresentedDoneReleaseNotificationAlert)
+        .doneReserveNotificationAlertModifier(isPresented: $mainViewModel.isPresentedDoneReserveNotificationAlert)
     }
 
     //背景色

--- a/WeatherAppSwiftUI/View/MainView.swift
+++ b/WeatherAppSwiftUI/View/MainView.swift
@@ -11,6 +11,7 @@ struct MainView: View {
     private var buttonWidth = UIScreen.main.bounds.width / 1.5
     private var settingTimeViewWidth = UIScreen.main.bounds.width * 0.8
     private var settingTimeViewHeight = UIScreen.main.bounds.height * 0.25
+    private let settingTimeViewColor = Color(uiColor: .darkGray)
 
     /// ナビゲーションバーの設定を行うメソッド
     func setupNavigationBar() {
@@ -95,10 +96,15 @@ struct MainView: View {
         LinearGradient(gradient: Gradient(colors: [.cyan, .white]), startPoint: .top, endPoint: .bottom)
             .ignoresSafeArea()
     }
+    /// buttonに使用する一部の枠線用
+    var partOfBorder: some View {
+        Rectangle()
+            .foregroundColor(Color(uiColor: .lightGray))
+    }
     /// 通知時間の設定画面（アラートに実装不可能なため）
     var settingTimeView: some View {
         ZStack {
-            Color(uiColor: .darkGray)
+            settingTimeViewColor
             VStack(spacing: 0) {
                 Text("通知を設定したい時間を選択")
                     .fontWeight(.bold)
@@ -106,26 +112,29 @@ struct MainView: View {
                     .padding()
                 Spacer()
                 DatePicker("時間を選択", selection: $mainViewModel.notificationTime, displayedComponents: .hourAndMinute)
+                    .scaleEffect(1.5)
                     .tint(.white)
                     .labelsHidden()
                 // Buttonを下部に揃える
                 Spacer()
                 // 上線
-                Rectangle().frame(width: settingTimeViewWidth, height: 1)
+                partOfBorder
+                    .frame(width: settingTimeViewWidth, height: 0.5)
                 HStack(spacing: 0) {
                     Button("キャンセル") {
                         mainViewModel.tappedReserveCancelButton()
                     }
                     .padding(.vertical)
                     .frame(width: settingTimeViewWidth / 2, height: settingTimeViewHeight / 4)
-                    .background(Color(uiColor: .lightGray))
-                    Rectangle().frame(width: 1, height: settingTimeViewHeight / 4)
+                    .background(settingTimeViewColor)
+                    partOfBorder
+                        .frame(width: 0.5, height: settingTimeViewHeight / 4)
                     Button("設定") {
                         mainViewModel.tappedReserveOkButton()
                     }
                     .padding(.vertical)
                     .frame(width: settingTimeViewWidth / 2, height: settingTimeViewHeight / 4)
-                    .background(Color(uiColor: .lightGray))
+                    .background(settingTimeViewColor)
                 }
             }
         }

--- a/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
+++ b/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
@@ -14,7 +14,8 @@ class MainViewModel: ObservableObject {
     @Published var isDisplayDetailView = false
     @Published var isDisplayNotGetLocDialog = false
     /// 通知予約の有無を示す変数
-    @Published var isNotification = false
+    /// @AppStorage("キー")を付与するだけで、普通の変数として扱える。（UserDefaultsに値を保存する→再起動時のアイコンに反映のため）
+    @AppStorage("isNotification") var isNotification = false
     // 通知解除アラート表示フラグ
     @Published var isPresentedReleaseNotificationAlert = false
     // 通知予約アラート表示フラグ

--- a/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
+++ b/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
@@ -73,6 +73,7 @@ class MainViewModel: ObservableObject {
                 if settings.authorizationStatus == .authorized {
                     print("通知許可済")
                     self.isNotificationPermissionStatus = true
+                    self.checkReservedNotification()
                 } else {
                     print("通知未許可")
                     self.isNotificationPermissionStatus = false
@@ -81,7 +82,7 @@ class MainViewModel: ObservableObject {
             }
         }
     }
-    /// 通知の有無を確認する
+    /// 通知予約の有無を確認する
     func checkReservedNotification() {
         /// 通知予約有無の判定
         UNUserNotificationCenter.current().getPendingNotificationRequests { [weak self] array in
@@ -104,7 +105,6 @@ class MainViewModel: ObservableObject {
     func tappedNotificationButton() {
         print("通知ボタンが押された")
         checkNotificationPermission()
-        checkReservedNotification()
     }
     /// 通知予約アラートのOKボタンが押された時
     func tappedReserveOkButton() {

--- a/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
+++ b/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
@@ -16,6 +16,11 @@ class MainViewModel: ObservableObject {
     /// 通知予約の有無を示す変数
     @Published var isNotification = false
     
+    @Published var isPresentedReleaseNotificationAlert = false
+    @Published var isPresentedReserveNotificationAlert = false
+    @Published var isPresentedDoneReleaseNotificationAlert = false
+    @Published var isPresentedDoneReserveNotificationAlert = false
+    
     /// 通知アイコン名を返すメソッド
     func notificationImageName() -> String {
         switch isNotification {
@@ -44,4 +49,54 @@ class MainViewModel: ObservableObject {
             isDisplayNotGetLocDialog = true
         }
     }
+    /// 通知ボタンが押された時の処理
+    func tappedNotificationButton() {
+        print("通知ボタンが押された")
+        if isNotification {
+            print("通知予約あり")
+            isPresentedReleaseNotificationAlert = true
+        } else {
+            print("通知予約なし")
+            isPresentedReserveNotificationAlert = true
+        }
+    }
+    /// 通知予約アラートのOKボタンが押された時
+    func tappedReserveOkButton() {
+        reserveNotification()
+        isPresentedDoneReserveNotificationAlert = true
+    }
+    /// 通知解除アラートのOKボタンが押された時
+    func tappedReleaseOkButton() {
+        releaseNotification()
+        isPresentedDoneReleaseNotificationAlert = true
+    }
+    
+    /// 通知を予約する（標準ではバックグラウンド通知のみ、フォアグラウンドは別途設定する必要あり）
+    func reserveNotification() {
+        // 通知内容の設定
+        let content = UNMutableNotificationContent()
+        content.title = "今後の天気は・・・？"
+        content.body = "通知をタップして、天気予報を確認しよう！"
+        content.sound = .default
+        
+        // 通知したい時間を作成
+        var dateComponents = DateComponents()
+        dateComponents.hour = Date().hour
+        dateComponents.minute = Date().minute + 2
+        // 通知トリガーの設定（毎日同時刻に）
+        let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+        // 通知リクエストの作成
+        let request = UNNotificationRequest(identifier: "DailyNotification", content: content, trigger: trigger)
+        // リクエストを追加
+        UNUserNotificationCenter.current().add(request)
+        isNotification = true
+        print("通知予約完了")
+    }
+    /// 予約した通知を解除する
+    func releaseNotification() {
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+        isNotification = false
+        print("通知予約解除した")
+    }
+    
 }

--- a/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
+++ b/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
@@ -70,19 +70,30 @@ class MainViewModel: ObservableObject {
             DispatchQueue.main.async {
                 guard let self = self else { return }
                 if settings.authorizationStatus == .authorized {
-                    self.isNotificationPermissionStatus = true
-                    if self.isNotification {
-                        print("通知予約あり")
-                        self.isPresentedReleaseNotificationAlert = true
-                    } else {
-                        print("通知予約なし")
-                        self.isPresentedReserveNotificationAlert = true
-                        }
                     print("通知許可済")
+                    self.isNotificationPermissionStatus = true
                 } else {
-                    self.isNotificationPermissionStatus = false
                     print("通知未許可")
+                    self.isNotificationPermissionStatus = false
                     self.isNotNotificationAlert = true
+                }
+            }
+        }
+    }
+    /// 通知の有無を確認する
+    func checkReservedNotification() {
+        /// 通知予約有無の判定
+        UNUserNotificationCenter.current().getPendingNotificationRequests { [weak self] array in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                if array.isEmpty {
+                    print("通知予約なし")
+                    self.isNotification = false
+                    self.isPresentedReserveNotificationAlert = true
+                } else {
+                    print("通知予約あり")
+                    self.isNotification = true
+                    self.isPresentedReleaseNotificationAlert = true
                 }
             }
         }
@@ -92,6 +103,7 @@ class MainViewModel: ObservableObject {
     func tappedNotificationButton() {
         print("通知ボタンが押された")
         checkNotificationPermission()
+        checkReservedNotification()
     }
     /// 通知予約アラートのOKボタンが押された時
     func tappedReserveOkButton() {

--- a/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
+++ b/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
@@ -22,6 +22,8 @@ class MainViewModel: ObservableObject {
     @Published var isPresentedDoneReserveNotificationAlert = false
     @Published var notificationTime = Date()
     @Published var isSettingTime = false
+    @Published var isNotificationPermission = false
+    @Published var isNotNotificationAlert = false
     
     func notificationTimeString() -> String {
         return notificationTime.formatJapaneseTimeStyle
@@ -55,15 +57,34 @@ class MainViewModel: ObservableObject {
             isDisplayNotGetLocDialog = true
         }
     }
+    /// 通知の許諾状態を確認する
+    func checkNotificationPermission() {
+        UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                if settings.authorizationStatus == .authorized {
+                    self.isNotificationPermission = true
+                } else {
+                    self.isNotificationPermission = false
+                }
+            }
+        }
+    }
+    
     /// 通知ボタンが押された時の処理
     func tappedNotificationButton() {
-        print("通知ボタンが押された")
-        if isNotification {
-            print("通知予約あり")
-            isPresentedReleaseNotificationAlert = true
+        checkNotificationPermission()
+        if isNotificationPermission {
+            print("通知ボタンが押された")
+            if isNotification {
+                print("通知予約あり")
+                isPresentedReleaseNotificationAlert = true
+            } else {
+                print("通知予約なし")
+                isPresentedReserveNotificationAlert = true
+            }
         } else {
-            print("通知予約なし")
-            isPresentedReserveNotificationAlert = true
+            isNotNotificationAlert = true
         }
     }
     /// 通知予約アラートのOKボタンが押された時

--- a/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
+++ b/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
@@ -15,14 +15,21 @@ class MainViewModel: ObservableObject {
     @Published var isDisplayNotGetLocDialog = false
     /// 通知予約の有無を示す変数
     @Published var isNotification = false
-    
+    // 通知解除アラート表示フラグ
     @Published var isPresentedReleaseNotificationAlert = false
+    // 通知予約アラート表示フラグ
     @Published var isPresentedReserveNotificationAlert = false
+    // 通知解除完了アラート表示フラグ
     @Published var isPresentedDoneReleaseNotificationAlert = false
+    // 通知予約完了アラート表示フラグ
     @Published var isPresentedDoneReserveNotificationAlert = false
+    // 通知の時間
     @Published var notificationTime = Date()
+    // 時間設定画面の表示フラグ
     @Published var isSettingTime = false
-    @Published var isNotificationPermission = false
+    // 通知の許諾状態を示す(trueで通知許可）
+    @Published var isNotificationPermissionStatus = false
+    // 通知未許可時のアラート表示フラグ
     @Published var isNotNotificationAlert = false
     
     func notificationTimeString() -> String {
@@ -63,9 +70,19 @@ class MainViewModel: ObservableObject {
             DispatchQueue.main.async {
                 guard let self = self else { return }
                 if settings.authorizationStatus == .authorized {
-                    self.isNotificationPermission = true
+                    self.isNotificationPermissionStatus = true
+                    if self.isNotification {
+                        print("通知予約あり")
+                        self.isPresentedReleaseNotificationAlert = true
+                    } else {
+                        print("通知予約なし")
+                        self.isPresentedReserveNotificationAlert = true
+                        }
+                    print("通知許可済")
                 } else {
-                    self.isNotificationPermission = false
+                    self.isNotificationPermissionStatus = false
+                    print("通知未許可")
+                    self.isNotNotificationAlert = true
                 }
             }
         }
@@ -73,19 +90,8 @@ class MainViewModel: ObservableObject {
     
     /// 通知ボタンが押された時の処理
     func tappedNotificationButton() {
+        print("通知ボタンが押された")
         checkNotificationPermission()
-        if isNotificationPermission {
-            print("通知ボタンが押された")
-            if isNotification {
-                print("通知予約あり")
-                isPresentedReleaseNotificationAlert = true
-            } else {
-                print("通知予約なし")
-                isPresentedReserveNotificationAlert = true
-            }
-        } else {
-            isNotNotificationAlert = true
-        }
     }
     /// 通知予約アラートのOKボタンが押された時
     func tappedReserveOkButton() {

--- a/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
+++ b/WeatherAppSwiftUI/ViewModel/MainViewModel.swift
@@ -20,6 +20,12 @@ class MainViewModel: ObservableObject {
     @Published var isPresentedReserveNotificationAlert = false
     @Published var isPresentedDoneReleaseNotificationAlert = false
     @Published var isPresentedDoneReserveNotificationAlert = false
+    @Published var notificationTime = Date()
+    @Published var isSettingTime = false
+    
+    func notificationTimeString() -> String {
+        return notificationTime.formatJapaneseTimeStyle
+    }
     
     /// 通知アイコン名を返すメソッド
     func notificationImageName() -> String {
@@ -63,7 +69,12 @@ class MainViewModel: ObservableObject {
     /// 通知予約アラートのOKボタンが押された時
     func tappedReserveOkButton() {
         reserveNotification()
+        isSettingTime = false
         isPresentedDoneReserveNotificationAlert = true
+    }
+    /// 通知予約アラートのキャンセルボタンが押された時
+    func tappedReserveCancelButton() {
+        isSettingTime = false
     }
     /// 通知解除アラートのOKボタンが押された時
     func tappedReleaseOkButton() {
@@ -81,8 +92,8 @@ class MainViewModel: ObservableObject {
         
         // 通知したい時間を作成
         var dateComponents = DateComponents()
-        dateComponents.hour = Date().hour
-        dateComponents.minute = Date().minute + 2
+        dateComponents.hour = notificationTime.hour
+        dateComponents.minute = notificationTime.minute
         // 通知トリガーの設定（毎日同時刻に）
         let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
         // 通知リクエストの作成


### PR DESCRIPTION
## チケットへのリンク

- #12 

## やったこと

- ローカル通知の実装（フォアグラウンドは想定しないため、バックグラウンドのみ）
- アラートにDatePickerを配置できないため、ZStackでViewを表に出す方法で実現させた。
- 通知未許可時にもアラートを出すようにした
- 通知予約の有無をアイコンで判断可能にした

## やらないこと（あれば。無いなら「無し」でOK。やらない場合は、いつやるのかを明記する。）

- フォアグラウンド通知

## 動作確認

- 実機：iPhone13Pro,シミュレータ：iPhone14ProMax, SE

## その他：レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

- SwiftUIは、アラートの実装が簡単な反面、自由度が少なく感じた。
- Uikitと組み合わせることで実現は可能とのこと。
