### PR TITLE
Fix/display location permission

### DIFF
--- a/WeatherAppSwiftUI/Model/LocationClient.swift
+++ b/WeatherAppSwiftUI/Model/LocationClient.swift
@@ -25,9 +25,12 @@ final class LocationClient: NSObject, ObservableObject {
     private override init() {
         super.init()
         locationManager.delegate = self
-        // アプリ起動時に位置情報許諾（App使用中の許可）ダイアログの表示
+    }
+    /// 位置情報許諾を表示するメソッド
+    func requestAuthorization() {
         locationManager.requestWhenInUseAuthorization()
     }
+    
     /// 位置情報取得許諾状態を表すプロパティ。許可されていればTrue
     var isAuthorized: Bool {
         let status = locationManager.authorizationStatus

--- a/WeatherAppSwiftUI/View/MainView.swift
+++ b/WeatherAppSwiftUI/View/MainView.swift
@@ -161,7 +161,7 @@ struct MainView: View {
         }
         .onAppear() {
             // アプリ起動時に位置情報許諾（App使用中の許可）ダイアログの表示
-            LocationClient.shared.requestAuthorization()t
+            LocationClient.shared.requestAuthorization()
         }
         .navigationTitle(Text("Home"))
         .navigationBarTitleDisplayMode(.inline)

--- a/WeatherAppSwiftUI/View/MainView.swift
+++ b/WeatherAppSwiftUI/View/MainView.swift
@@ -159,7 +159,10 @@ struct MainView: View {
                 settingTimeView
             }
         }
-
+        .onAppear() {
+            // アプリ起動時に位置情報許諾（App使用中の許可）ダイアログの表示
+            LocationClient.shared.requestAuthorization()t
+        }
         .navigationTitle(Text("Home"))
         .navigationBarTitleDisplayMode(.inline)
         // 戻るボタンを非表示


### PR DESCRIPTION
## チケットへのリンク

- #26 

## やったこと

- 位置情報許諾ダイアログの表示タイミング見直し
- init()に記載していたが、アプリ起動時に呼び出されれていなかったので、onApperに移行した

## やらないこと（あれば。無いなら「無し」でOK。やらない場合は、いつやるのかを明記する。）

- なし

## 動作確認

- 実機：iPhone13Pro

## その他：レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

- なし
