### PR TITLE
グラフの横軸ラベル表示見直し

### DIFF
--- a/WeatherAppSwiftUI/View/DetailView.swift
+++ b/WeatherAppSwiftUI/View/DetailView.swift
@@ -58,7 +58,8 @@ struct DetailView: View {
         // X軸の設定
         .chartXAxis {
             // 3時間ごとにラベルをつける（表示間隔の調整)
-            AxisMarks(values: .stride(by: .hour, count: 3), content: { value in
+            // presetに.alignedを指定することで、グリッド線の下部に来て、最後のラベルも表示可能となる
+            AxisMarks(preset: .aligned, values: .stride(by: .hour, count: 3), content: { value in
                 // グリッドラインの表示
                 AxisGridLine()
                     .foregroundStyle(.gray)


### PR DESCRIPTION
## チケットへのリンク

- #27 

## やったこと

- グラフの横軸ラベルの、時間が表示されていない不具合修正
- 見切れではなく、Chartsの標準仕様と思われる
- AxisMarksのpresetに.alignedを指定することで、グリッド線の直下にラベルが配置され、最後のラベルも表示可能となる

## やらないこと（あれば。無いなら「無し」でOK。やらない場合は、いつやるのかを明記する。）

- なし


## 動作確認

- 実機：iPhone13Pro
- シミュレータ：iPhone SE

## その他：レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

- 標準仕様で解決不能だと諦めた矢先に、ふとY軸で微調整してる記事を見かけ、X軸でもできるのではと試したらできました
-
<img width="770" alt="スクリーンショット 2023-07-26 16 16 16" src="https://github.com/yuu123456/WeatherAppSwiftUI/assets/106535171/a598d1fc-f6df-4034-aa3f-631b74777167">

